### PR TITLE
Remove an empty path in list

### DIFF
--- a/lib/douglas-view.coffee
+++ b/lib/douglas-view.coffee
@@ -79,7 +79,7 @@ class DouglasView extends SelectListView
     ghq.rootAll (outputs) =>
       @roots = outputs.trim().split('\n')
       ghq.list '--full-path', (outputs) ->
-        callback outputs.split '\n'
+        callback outputs.trim().split('\n')
 
   _normalizeItem: (fullPath) ->
     relativePath = fullPath


### PR DESCRIPTION
This removes an empty path which is added to the end of list because of a trailing space in the output of `ghq.list`.
